### PR TITLE
Fix bug in path when locale is empty

### DIFF
--- a/lib/Config/Project.php
+++ b/lib/Config/Project.php
@@ -165,22 +165,25 @@ class Project {
 			return $path . "{$locale}.{$this->config['ext']}";
 		}
 
+		$filename_parts = [];
+
 		if ( isset( $this->config['filename'] ) ) {
-			$path .= "{$this->config['filename']}-";
+			$filename_parts[] = "{$this->config['filename']}";
 
 		} elseif ( isset( $this->config['domain'] ) ) {
-			$path .= "{$this->config['domain']}-";
+			$filename_parts[] = "{$this->config['domain']}";
 		}
 
 		if ( ! empty( $locale ) ) {
-			$path .= "{$locale}";
+			$filename_parts[] = "{$locale}";
 		}
 
 		// TODO: Should we only add this if the format/ext is also jed/json?
 		if ( isset( $this->config['js-handle'] ) ) {
-			$path .= "-{$this->config['js-handle']}";
+			$filename_parts[] = "{$this->config['js-handle']}";
 		}
 
+		$path .= implode( '-', $filename_parts );
 		return "{$path}.{$this->config['ext']}";
 	}
 

--- a/tests/Config/ProjectTest.php
+++ b/tests/Config/ProjectTest.php
@@ -375,7 +375,16 @@ class ProjectTest extends TestCase {
 				],
 				'pt_PT',
 				"{$path}pt_PT.{$ext}",
-			]
+			],
+			'Without locale (pots)' => [
+				[
+					'path'   => $path,
+					'ext'    => $ext,
+					'domain' => $domain,
+				],
+				'',
+				"{$path}{$domain}.{$ext}",
+			],
 		];
 	}
 

--- a/tests/Config/ProjectTest.php
+++ b/tests/Config/ProjectTest.php
@@ -376,7 +376,7 @@ class ProjectTest extends TestCase {
 				'pt_PT',
 				"{$path}pt_PT.{$ext}",
 			],
-			'Without locale (pots)' => [
+			'Empty locale' => [
 				[
 					'path'   => $path,
 					'ext'    => $ext,


### PR DESCRIPTION
When locale was empty a '-' was being placed at the end of the filename.

Also added a test case for this.