### PR TITLE
Lock file handler and localise last-modified

### DIFF
--- a/lib/Clients/Service/Localise.php
+++ b/lib/Clients/Service/Localise.php
@@ -92,11 +92,7 @@ class Localise extends Client {
 		$res = $this->client->request(
 			'GET',
 			$url,
-			[
-				'headers' => [
-					'If-Modified-Since' => $lock['localise'][ $proj_name ]['Last-Modified'] ?? '',
-				],
-			]
+			$this->get_export_options( $lock, $proj_name )
 		);
 
 		$lock['localise'][ $proj_name ]['Last-Modified'] = $res->getHeaders()['Last-Modified'][0];
@@ -156,5 +152,30 @@ class Localise extends Client {
 		}
 
 		return '?' . implode( '&', $query_string );
+	}
+
+	/**
+	 * Get options for export.
+	 *
+	 * Check env or constant value for not checking if export has been modified since.
+	 *
+	 * @since  0.0.0
+	 * @param  LockHandler $lock
+	 * @param  string      $proj_name
+	 * @return array
+	 */
+	private function get_export_options( LockHandler $lock, string $proj_name ) : array {
+		if (
+			getenv( 'DONT_CHECK_MODIFIED' ) === 'true'
+			|| ( defined( 'DONT_CHECK_MODIFIED' ) && constant( 'DONT_CHECK_MODIFIED' ) )
+		) {
+			return [];
+		}
+
+		return [
+			'headers' => [
+				'If-Modified-Since' => $lock['localise'][ $proj_name ]['Last-Modified'] ?? '',
+			],
+		];
 	}
 }

--- a/lib/LockHandler.php
+++ b/lib/LockHandler.php
@@ -6,21 +6,61 @@ use ArrayObject;
 
 /**
  * Handles the lock file, reading and writing.
+ *
+ * @since      0.0.0
+ * @package    TODO:
+ * @subpackage TODO:
+ * @author     TODO:
  */
 class LockHandler extends ArrayObject {
 
+	/**
+	 * Singleton instance.
+	 *
+	 * @since 0.0.0
+	 * @var   null|LockHandler
+	 */
 	private static $instance = null;
 
+	/**
+	 * Lock file name.
+	 *
+	 * @since 0.0.0
+	 * @var   string
+	 */
 	const FILENAME = 'midoru.lock';
 
+	/**
+	 * File path to lock.
+	 *
+	 * @since 0.0.0
+	 * @var   string
+	 */
 	private $path = '';
 
+	/**
+	 * MD5 of the data read on the first instance. Used for dirty state handling.
+	 *
+	 * @since 0.0.0
+	 * @var   string
+	 */
 	private $md5 = '';
 
-	public static function get_instance() {
+	/**
+	 * Get the singleton instance or create one if it doesn't exist.
+	 *
+	 * @since  0.0.0
+	 * @return LockHandler
+	 */
+	public static function get_instance() : LockHandler {
 		return self::$instance === null ? self::$instance = new LockHandler() : self::$instance;
 	}
 
+	/**
+	 * Read the data from lock file if it exists.
+	 *
+	 * @since 0.0.0
+	 */
 	private function __construct() {
 		$this->path = getcwd() . '/' . self::FILENAME;
 		$file       = fopen( $this->path, 'r' );
@@ -37,18 +77,28 @@ class LockHandler extends ArrayObject {
 		parent::__construct( $data );
 	}
 
-	public function write() {
+	/**
+	 * Write the currently loaded data to the lock file, if there are any changes.
+	 *
+	 * @since  0.0.0
+	 * @return void
+	 * @throws Exception When file open fails.
+	 */
+	public function write() : void {
 		$data = $this->getArrayCopy();
 
 		// Avoid unnecessary writes.
-		if ( md5( json_encode( $data ) ) === $this->md5 ) {
+		$new_md5 = md5( json_encode( $data ) );
+		if ( $new_md5 === $this->md5 ) {
 			return;
 		}
 
 		$file = fopen( $this->path, 'w' );
 		if ( ! $file ) {
-			throw new \Exception( 'Failure to write lock file.' );
+			throw new \Exception( 'Failure to open lock file for writing.' );
 		}
+
+		$this->md5 = $new_md5;
 
 		// TODO: Should we save the file its empty?
 		fwrite( $file, empty( $data ) ? '{}' : json_encode( $data, JSON_PRETTY_PRINT ) );

--- a/lib/LockHandler.php
+++ b/lib/LockHandler.php
@@ -28,7 +28,7 @@ class LockHandler extends ArrayObject {
 	 * @since 0.0.0
 	 * @var   string
 	 */
-	const FILENAME = 'midoru.lock';
+	const FILENAME = 'i18n-midoru.lock';
 
 	/**
 	 * File path to lock.

--- a/lib/LockHandler.php
+++ b/lib/LockHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace TwentySixB\Translations;
+
+use ArrayObject;
+
+/**
+ * Handles the lock file, reading and writing.
+ */
+class LockHandler extends ArrayObject {
+
+	private static $instance = null;
+
+	const FILENAME = 'midoru.lock';
+
+	private $path = '';
+
+	private $md5 = '';
+
+	public static function get_instance() {
+		return self::$instance === null ? self::$instance = new LockHandler() : self::$instance;
+	}
+
+	private function __construct() {
+		$this->path = getcwd() . '/' . self::FILENAME;
+		$file       = fopen( $this->path, 'r' );
+
+		$data = [];
+		if ( $file ) {
+			$data = json_decode( fread( $file, filesize( $this->path ) ), true );
+			fclose( $file );
+		}
+
+		// We use md5 to verify dirty state due to weird behavior of ArrayObject with indirect modification.
+		$this->md5 = md5( json_encode( $data ) );
+
+		parent::__construct( $data );
+	}
+
+	public function write() {
+		$data = $this->getArrayCopy();
+
+		// Avoid unnecessary writes.
+		if ( md5( json_encode( $data ) ) === $this->md5 ) {
+			return;
+		}
+
+		$file = fopen( $this->path, 'w' );
+		if ( ! $file ) {
+			throw new \Exception( 'Failure to write lock file.' );
+		}
+
+		// TODO: Should we save the file its empty?
+		fwrite( $file, empty( $data ) ? '{}' : json_encode( $data, JSON_PRETTY_PRINT ) );
+		fclose( $file );
+	}
+}

--- a/lib/LockHandler.php
+++ b/lib/LockHandler.php
@@ -63,7 +63,7 @@ class LockHandler extends ArrayObject {
 	 */
 	private function __construct() {
 		$this->path = getcwd() . '/' . self::FILENAME;
-		$file       = fopen( $this->path, 'r' );
+		$file       = @fopen( $this->path, 'r' );
 
 		$data = [];
 		if ( $file ) {

--- a/lib/Translations.php
+++ b/lib/Translations.php
@@ -46,6 +46,8 @@ class Translations {
 			$downloader->save( $downloads );
 			print( "Translation files downloaded and saved successfully.\n" );
 		}
+
+		LockHandler::get_instance()->write();
 	}
 
 	/**

--- a/lib/Translations/Download.php
+++ b/lib/Translations/Download.php
@@ -19,6 +19,7 @@ class Download extends ServiceBase {
 	 * @var   array
 	 */
 	const ACCEPTED_EXPORT_KEYS = [
+		'__project_name', // The project from the config.
 		'locale',
 		'ext',
 		'format',
@@ -77,8 +78,9 @@ class Download extends ServiceBase {
 	 * @return array
 	 */
 	private function make_export_config( string $locale ) : array {
-		$config           = $this->config->get_config();
-		$config['locale'] = $locale;
+		$config                   = $this->config->get_config();
+		$config['locale']         = $locale;
+		$config['__project_name'] = $this->config->get_name();
 		return array_filter(
 			$config,
 			function ( $key ) {


### PR DESCRIPTION
#22 
Creating a handler for the lock file. Updating localise client to use and save last-modified exporting.

The lock handler is a singleton so we don't have to pass the handler from one place to another, and to save unnecessary reads of the lock file. It extends `ArrayObject` so we can use it like this:
```php
$lock['localise']['project']['Last-Modified'] = 'date';

$last_modified = $lock['localise']['project']['Last-Modified'];
```

In order to bypass this validation of the file having been modified, you can use an env variable or constant with the key `DONT_CHECK_MODIFIED` with the value `true` (string in case of env, and bool incase of constant).