### PR TITLE
Add xdebug to github actions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,6 +20,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.3'
+        coverage: xdebug
 
     - name: Validate composer.json and composer.lock files
       run: composer validate --no-interaction


### PR DESCRIPTION
Failing tests because `setup-php@v2` was updated and now needs `xdebug`.