### PR TITLE
Filter translation operations by project names

### DIFF
--- a/lib/Config/Config.php
+++ b/lib/Config/Config.php
@@ -44,13 +44,18 @@ class Config {
 	 * Get the merged data from all the input sources provided in the constructor.
 	 *
 	 * @since  0.0.0
-	 * @param  string $purpose Name of the purpose.
-	 * @return array           Array of Projects.
+	 * @param  string   $purpose         Name of the purpose.
+	 * @param  string[] $wanted_projects Array of project names to get configuration for. Default is
+	 *                                   an empty array, all projects are retrieved.
+	 * @return array                     Array of Projects.
 	 */
-	public function get( string $purpose ) : array {
+	public function get( string $purpose, array $wanted_projects = [] ) : array {
 		$project_configs = [];
 		foreach ( $this->config as $project_name => $config ) {
-			if ( ! isset( $config[ $purpose ] ) ) {
+			if (
+				! isset( $config[ $purpose ] )
+				|| ( ! empty( $wanted_projects ) && ! in_array( $project_name, $wanted_projects, true ) )
+			) {
 				continue;
 			}
 			$project_configs[] = new Project(

--- a/lib/Translations.php
+++ b/lib/Translations.php
@@ -24,13 +24,15 @@ class Translations {
 	/**
 	 * Download translations.
 	 *
+	 * @param  string[] $wanted_projects Array of project names to make_pots for. Default is an
+	 *                                   empty array, all projects with `export` are considered.
 	 * @return void
 	 * @throws AuthorizationFailed
 	 * @throws FilenameArgumentNotAvailable
 	 * @throws Exception
 	 */
-	public function download() {
-		$projects_config = $this->config->get( 'export' );
+	public function download( array $wanted_projects = [] ) {
+		$projects_config = $this->config->get( 'export', $wanted_projects );
 
 		// Maybe handle project iteration here.
 		foreach ( $projects_config as $config ) {
@@ -52,13 +54,15 @@ class Translations {
 	/**
 	 * Upload files for translation.
 	 *
+	 * @param  string[] $wanted_projects Array of project names to make_pots for. Default is an
+	 *                                   empty array, all projects with `import` are considered.
 	 * @return void
 	 * @throws AuthorizationFailed
 	 * @throws FilenameArgumentNotAvailable
 	 * @throws Exception
 	 */
-	public function upload() {
-		$projects_config = $this->config->get( 'import' );
+	public function upload( array $wanted_projects = [] ) {
+		$projects_config = $this->config->get( 'import', $wanted_projects );
 
 		// Maybe handle project iteration here.
 		foreach ( $projects_config as $config ) {
@@ -74,14 +78,16 @@ class Translations {
 	/**
 	 * Make pot files.
 	 *
+	 * @param  string[] $wanted_projects Array of project names to make_pots for. Default is an
+	 *                                   empty array, all projects with `make_posts` are considered.
 	 * @return void
 	 * @throws DirectoryDoesntExist
 	 * @throws NoFilenameAvailableForPotFile
 	 * @throws FilenameArgumentNotAvailable
 	 * @throws Exception
 	 */
-	public function make_pots() {
-		$projects_config = $this->config->get( 'make_pots' );
+	public function make_pots( array $wanted_projects = [] ) {
+		$projects_config = $this->config->get( 'make_pots', $wanted_projects );
 
 		// Maybe handle project iteration here.
 		foreach ( $projects_config as $config ) {


### PR DESCRIPTION
Adds the ability to filter by project names the translation operations `download`, `upload` and `make_pots.`