### PR TITLE
Handle character accents in json

### DIFF
--- a/lib/Translations.php
+++ b/lib/Translations.php
@@ -113,7 +113,7 @@ class Translations {
 				[
 					'locale_data' => json_decode( $json, true ),
 				],
-				JSON_PRETTY_PRINT
+				JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE
 			);
 		}
 		return $jsons;


### PR DESCRIPTION
Encode the accented character literally and not with "\uXXXXX" in json files.

closes #5 