### PR TITLE
Visibility for Project Name on Exceptions

### DIFF
--- a/lib/Clients/Service/Localise.php
+++ b/lib/Clients/Service/Localise.php
@@ -113,16 +113,17 @@ class Localise extends Client {
 			throw new Exception( 'Authenticate should be called first' );
 		}
 
-		$url  = sprintf( 'import/%s', $args['ext'] );
-		$body = $args['data'];
-		unset( $args['ext'], $args['data'] );
+		$proj_name = $args['__project_name'];
+		$url       = sprintf( 'import/%s', $args['ext'] );
+		$body      = $args['data'];
+		unset( $args['__project_name'], $args['ext'], $args['data'], );
 
 		$url .= empty( $args ) ? '' : '?' . http_build_query( $args );
 
 		try {
 			$res = $this->client->request( 'POST', $url, [ 'body' => $body ] );
 		} catch ( GuzzleException $e ) {
-			print( "\nException thrown while uploading for project '{$args['__project_name']}'." );
+			print( "\nException thrown while uploading for project '{$proj_name}'." );
 			throw $e;
 		}
 

--- a/lib/Clients/Service/Localise.php
+++ b/lib/Clients/Service/Localise.php
@@ -3,6 +3,7 @@
 namespace TwentySixB\Translations\Clients\Service;
 
 use Exception;
+use GuzzleHttp\Exception\GuzzleException;
 use TwentySixB\Translations\Exceptions\AuthorizationFailed;
 use TwentySixB\Translations\LockHandler;
 
@@ -46,11 +47,12 @@ class Localise extends Client {
 			]
 		);
 
-		$res = $client->request(
-			'GET',
-			'auth/verify',
-			[]
-		);
+		try {
+			$res = $client->request( 'GET', 'auth/verify', [] );
+		} catch ( GuzzleException $e ) {
+			print( "\nException thrown while authenticating for project '{$args['__project_name']}'." );
+			throw $e;
+		}
 
 		if ( $res->getStatusCode() !== 200 ) {
 			throw new AuthorizationFailed( 'Authorization was not successful.' );
@@ -86,7 +88,12 @@ class Localise extends Client {
 
 		$url .= empty( $args ) ? '' : '?' . http_build_query( $args );
 
-		$res = $this->client->request( 'GET', $url, $this->get_export_options( $last_modified ) );
+		try {
+			$res = $this->client->request( 'GET', $url, $this->get_export_options( $last_modified ) );
+		} catch ( GuzzleException $e ) {
+			print( "\nException thrown while downloading for project '{$proj_name}'." );
+			throw $e;
+		}
 
 		LockHandler::get_instance()->set( $proj_name, 'Last-Modified', $res->getHeaders()['Last-Modified'][0] );
 
@@ -112,7 +119,12 @@ class Localise extends Client {
 
 		$url .= empty( $args ) ? '' : '?' . http_build_query( $args );
 
-		$res = $this->client->request( 'POST', $url, [ 'body' => $body ] );
+		try {
+			$res = $this->client->request( 'POST', $url, [ 'body' => $body ] );
+		} catch ( GuzzleException $e ) {
+			print( "\nException thrown while uploading for project '{$args['__project_name']}'." );
+			throw $e;
+		}
 
 		return json_decode( $res->getBody()->__toString(), true );
 	}

--- a/lib/Translations/ServiceBase.php
+++ b/lib/Translations/ServiceBase.php
@@ -42,7 +42,10 @@ abstract class ServiceBase {
 	protected function authenticate() {
 		$client = $this->config->get_client();
 		return $client->authenticate(
-			[ 'key' => $this->config->get_api_key( $client->get_api_key_prefix() ) ]
+			[
+				'key'            => $this->config->get_api_key( $client->get_api_key_prefix() ),
+				'__project_name' => $this->config->get_name(),
+			]
 		);
 	}
 }

--- a/lib/Translations/Upload.php
+++ b/lib/Translations/Upload.php
@@ -22,6 +22,7 @@ class Upload extends ServiceBase {
 	 * @var   array
 	 */
 	const ACCEPTED_IMPORT_KEYS = [
+		'__project_name', // The project from the config.
 		'locale',
 		'ext',
 		'data',
@@ -72,9 +73,10 @@ class Upload extends ServiceBase {
 	 * @return array
 	 */
 	private function make_import_config( string $locale, string $data ) : array {
-		$config           = $this->config->get_config();
-		$config['locale'] = $locale;
-		$config['data']   = $data;
+		$config                    = $this->config->get_config();
+		$config['__project_name']  = $this->config->get_name();
+		$config['locale']          = $locale;
+		$config['data']            = $data;
 		return array_filter(
 			$config,
 			function ( $key ) {


### PR DESCRIPTION
When the Guzzle Request for authentication/download/upload threw an exception, there was no way to tell what project failed, unless you went to your json file and checked what the next project would have been.